### PR TITLE
Use the port in the connection URL

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -28,7 +28,7 @@ if config_env() == :prod do
   pass = System.get_env("PGPASSWORD") || raise "environment variable PGPASSWORD is missing."
 
   # ecto://USER:PASS@HOST/DATABASE
-  database_url = "ecto://#{user}:#{pass}@#{host}/#{database}"
+  database_url = "ecto://#{user}:#{pass}@#{host}:#{port}/#{database}"
 
   maybe_ipv6 = if System.get_env("ECTO_IPV6") in ~w(true 1), do: [:inet6], else: []
 


### PR DESCRIPTION
Use the `port`/`PGPORT` in the PostgreSQL connection string.


---

Launching the template the deploy failed due to the `mix ecto.migrate` failing:

```
#16 4.990 ** (DBConnection.ConnectionError) connection not available and request was dropped from queue after 2969ms. This means requests are coming in and your connection pool cannot serve them fast enough. You can address this by:
```

After increasing the `:queue_target` and `:queue_interval` the deploy failure started logging:

```
#16 [error] Postgrex.Protocol (#PID<0.207.0>) failed to connect: ** (DBConnection.ConnectionError) tcp connect (monorail.proxy.rlwy.net:5432): timeout
```

The port is the default Postgres port, but the host is the publicly proxied Postgres service that runs on a different port. Then noticing the warning about the unused `port` variable jumped out as the problem.

```
#16 1.598 warning: variable "port" is unused (if the variable is not meant to be used, prefix it with an underscore)
```


